### PR TITLE
add negative tests

### DIFF
--- a/assets/empty.json
+++ b/assets/empty.json
@@ -1,0 +1,5 @@
+{
+    "programId": "",
+    "parameters": "",
+    "proof": ""
+}

--- a/cabal.project
+++ b/cabal.project
@@ -6,4 +6,4 @@ package test-lurk-hs
 source-repository-package
     type: git
     location: https://github.com/argumentcomputer/lurk-hs.git
-    tag: 77bdf6f4d289d8274f839822d590d05758bfb53d
+    tag: a4bbe826bb0bed3856469dfb0cf8151d857f9172

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -27,17 +27,20 @@ import Verify hiding (runExample)
 
 main :: IO ()
 main = hspec $ describe "examples" $ do
-    testExample "fibonacci_fixture"
-    testExample "epoch_change"
-    testExample "inclusion_fixture"
-
+    testSuccess "fibonacci_fixture"
+    testSuccess "epoch_change"
+    testSuccess "inclusion_fixture"
+    testFailure "empty"
+  where
+    testSuccess n = testExample n True
+    testFailure n = testExample n False
 -- --------------------------------------------------------------------------
 -- Run Example
 
-testExample :: String -> SpecWith ()
-testExample name = it name $ do
+testExample :: String -> Bool -> SpecWith ()
+testExample name expected = it name $ do
     r <- runExample name
-    shouldBe r True
+    shouldBe r expected
 
 -- Test the case when 'verifyPlonkBn254' is imported directly by the component.
 --

--- a/test/MainIndirect.hs
+++ b/test/MainIndirect.hs
@@ -42,15 +42,19 @@ makeLenses ''Proof
 
 main :: IO ()
 main = hspec $ describe "examples" $ do
-    testExample "fibonacci_fixture"
-    testExample "epoch_change"
-    testExample "inclusion_fixture"
+    testSuccess "fibonacci_fixture"
+    testSuccess "epoch_change"
+    testSuccess "inclusion_fixture"
+    testFailure "empty"
+  where
+    testSuccess n = testExample n True
+    testFailure n = testExample n False
 
 -- --------------------------------------------------------------------------
 -- Run Example
 
-testExample :: String -> SpecWith ()
-testExample name = it name $ do
+testExample :: String -> Bool -> SpecWith ()
+testExample name expected = it name $ do
     r <- runExample name
-    shouldBe r True
+    shouldBe r expected
 


### PR DESCRIPTION
adding a negative test, which currently results in a `panic` that can't be caught from Haskell.

```
run test:test-indirect                    
Build profile: -w ghc-9.8.2 -O1
In order, the following will be built (use -v for more details):
 - test-lurk-hs-0.1.0.0 (test:test-indirect) (file assets/empty.json changed)
Preprocessing library for test-lurk-hs-0.1.0.0..
Building library for test-lurk-hs-0.1.0.0..
Preprocessing test suite 'test-indirect' for test-lurk-hs-0.1.0.0..
Building test suite 'test-indirect' for test-lurk-hs-0.1.0.0..

examples
  fibonacci_fixture [ ]ignoring uninitialized slice: Vars []frontend.Variable
ignoring uninitialized slice: Vars []frontend.Variable
ignoring uninitialized slice: Vars []frontend.Variable
11:46:26 DBG verifier done backend=plonk curve=bn254 took=1.004042
  fibonacci_fixture [✔]
  epoch_change [ ]ignoring uninitialized slice: Vars []frontend.Variable
ignoring uninitialized slice: Vars []frontend.Variable
ignoring uninitialized slice: Vars []frontend.Variable
11:46:26 DBG verifier done backend=plonk curve=bn254 took=0.821792
  epoch_change [✔]
  inclusion_fixture [ ]ignoring uninitialized slice: Vars []frontend.Variable
ignoring uninitialized slice: Vars []frontend.Variable
ignoring uninitialized slice: Vars []frontend.Variable
11:46:26 DBG verifier done backend=plonk curve=bn254 took=0.87125
  inclusion_fixture [✔]
  empty [ ]thread '<unnamed>' panicked at src/lib.rs:99:60:
Failed to parse vkey
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread '<unnamed>' panicked at library/core/src/panicking.rs:221:5:
panic in a function that cannot unwind
stack backtrace:
   0:        0x1031bbb2c - std::backtrace_rs::backtrace::libunwind::trace::hbebc8679d47bdc2c
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/../../backtrace/src/backtrace/libunwind.rs:116:5
   1:        0x1031bbb2c - std::backtrace_rs::backtrace::trace_unsynchronized::h3a2e9637943241aa
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:        0x1031bbb2c - std::sys::backtrace::_print_fmt::he430849680584674
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sys/backtrace.rs:65:5
   3:        0x1031bbb2c - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h243268f17d714c7f
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sys/backtrace.rs:40:26
   4:        0x1031cf03c - core::fmt::rt::Argument::fmt::h0d339881c25f3c31
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/fmt/rt.rs:173:76
   5:        0x1031cf03c - core::fmt::write::hb3cfb8a30e72d7ff
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/fmt/mod.rs:1182:21
   6:        0x1031ba2b0 - std::io::Write::write_fmt::hfb2314975de9ecf1
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/io/mod.rs:1827:15
   7:        0x1031bcb48 - std::sys::backtrace::BacktraceLock::print::he14461129ccbfef5
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sys/backtrace.rs:43:9
   8:        0x1031bcb48 - std::panicking::default_hook::{{closure}}::h14c7718ccf39d316
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:269:22
   9:        0x1031bc76c - std::panicking::default_hook::hc62e60da3be2f352
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:296:9
  10:        0x1031bd55c - std::panicking::rust_panic_with_hook::h09e8a656f11e82b2
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:800:13
  11:        0x1031bcf34 - std::panicking::begin_panic_handler::{{closure}}::h1230eb3cc91b241c
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:667:13
  12:        0x1031bbfb8 - std::sys::backtrace::__rust_end_short_backtrace::hc3491307aceda2c2
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sys/backtrace.rs:168:18
  13:        0x1031bcc24 - rust_begin_unwind
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:665:5
  14:        0x104cededc - core::panicking::panic_nounwind_fmt::runtime::h5290ab2b4897aadc
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/panicking.rs:112:18
  15:        0x104cededc - core::panicking::panic_nounwind_fmt::h91ee161184879b56
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/panicking.rs:122:5
  16:        0x104cedf54 - core::panicking::panic_nounwind::heab7ebe7a6cd845c
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/panicking.rs:221:5
  17:        0x104cedff8 - core::panicking::panic_cannot_unwind::hedc43d82620205bf
                               at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/panicking.rs:309:5
  18:        0x102925214 - ___c_verify_plonk_bn254
thread caused non-unwinding panic. aborting.
zsh: abort      cabal run test:test-indirect
```